### PR TITLE
Update xep0156.md: Mention mod_http_altconnect

### DIFF
--- a/caas-web/src/main/resources/help/prosody/xep0156.md
+++ b/caas-web/src/main/resources/help/prosody/xep0156.md
@@ -23,3 +23,4 @@ Apache: Example code to add to `conf/httpd.conf` file:
     Header set Access-Control-Allow-Origin "*"
 </Location>
 ```
+If you're using the built-in Prosody web server, you can instead load the community module [mod_http_altconnect](https://modules.prosody.im/mod_http_altconnect.html), which creates the needed files automatically.


### PR DESCRIPTION
For server admins who use the built-in Prosody web server, this module creates the .well-known folder and the needed files automatically.